### PR TITLE
[hugo-updater] Update Hugo to version 0.106.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,5 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.105.0"
+  HUGO_VERSION = "0.106.0"
 


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.106.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.106.0

## Bug fixes

* Fix taxonomy weight sort regression 52ea07d2 @bep #10406 
* tlp/resources: resources.Get returns nil when given empty string db945a6e @shifterbit 
* tpl/internal: Sync go_templates f6ab9553 @bep #10411 

## Dependency Updates

* build(deps): bump github.com/pelletier/go-toml/v2 from 2.0.4 to 2.0.6 bafb389b @dependabot[bot] 
* build(deps): bump github.com/evanw/esbuild from 0.15.13 to 0.15.14 cdd83bf3 @dependabot[bot] 
* deps: Update the libweb version string e00220a0 @bep 
* deps: Upgrade github.com/bep/gowebp v0.1.0 => v0.2.0 a662ddae @bep 
* build(deps): bump github.com/yuin/goldmark from 1.5.2 to 1.5.3 fe08d35f @dependabot[bot] 
* build(deps): bump github.com/spf13/afero from 1.9.2 to 1.9.3 4b675ddd @dependabot[bot] 
* build(deps): bump github.com/getkin/kin-openapi from 0.107.0 to 0.108.0 24eaa290 @dependabot[bot] 
* build(deps): bump github.com/clbanning/mxj/v2 from 2.5.6 to 2.5.7 58a98c77 @dependabot[bot] 
* build(deps): bump golang.org/x/net from 0.1.0 to 0.2.0 900904fd @dependabot[bot] 
* build(deps): bump github.com/evanw/esbuild from 0.15.12 to 0.15.13 24eca0cb @dependabot[bot] 

## Documentation

* docs: Regen CLI docs 0a019a1a @bep 
* docs: Regenerate docs helper 9f7fb0a7 @bep 
* Add Go 1.16+ install method to README 60e0e2c1 @vgnh 
* readme: Update ToC 13adf3e0 @vgnh 


