### PR TITLE
[hugo-updater] Update Hugo to version 0.107.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,5 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.106.0"
+  HUGO_VERSION = "0.107.0"
 


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.107.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.107.0

This release is mostly interesting if you do code highlighting. We fixed a bottle neck which should show a significant performance boost for sites using code highlighting. Hugo's [gohugo.io](https://gohugo.io/) docs site builds ~20% faster. Also, Chroma, the highlighting library, is upgraded to [v2.4.0](https://github.com/alecthomas/chroma/releases/tag/v2.4.0) with new lexers and lots of improvements.

## Bug fixes

* hugo/parser: Fix shortcode boolean param parsing 00fe7e04 @jmooring #10451 

## Improvements

* Add a cache for lexers.Get 7855b47f @bep 
* markup/goldmark: Improve benchmark 34d1150d @bep 
* commands: Create assets directory with new site 85e2ac1a @jmooring #10460 

## Dependency Updates

* build(deps): bump github.com/getkin/kin-openapi from 0.108.0 to 0.109.0 6a004b8d @dependabot[bot] 
* build(deps): bump github.com/evanw/esbuild from 0.15.14 to 0.15.15 09236224 @dependabot[bot] 
* build(deps): bump github.com/frankban/quicktest from 1.14.3 to 1.14.4 74776726 @dependabot[bot] 
* build(deps): bump golang.org/x/tools from 0.2.0 to 0.3.0 63f7f0ff @dependabot[bot] 
* deps: Upgrade github.com/alecthomas/chroma/v2 v2.4.0 bcb62d89 @bep 


