### PR TITLE
[hugo-updater] Update Hugo to version 0.108.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,5 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.107.0"
+  HUGO_VERSION = "0.108.0"
 


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.108.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.108.0

With Hugo `v0.108.0` you can render standalone Markdown images without a surrounding paragraph. Both the HTML- and CommonMark-specification defines image as an inline element. For Markdown, this has meant that if you put an image on its own (not _inlined_ in another paragraph), it would be wrapped in `<p></p>` tags, even if you provide your own [Render Hook Template](https://gohugo.io/templates/render-hooks/).

Now you can get by this annoyance by setting `markup.goldmark.parser.wrapStandAloneImageWithinParagraph = false`

```toml
[markup]
  [markup.goldmark]
    [markup.goldmark.parser]
      wrapStandAloneImageWithinParagraph = false
      [markup.goldmark.parser.attribute]
        block = true
```

In the above we have also enabled attribute support for Markdown blocks to illustrate another nice side effect of this; it's now possible to use Markdown attributes (e.g. CSS classes) on standalone images:

```md
This is an inline image: ![Inline Image](/inline.jpg). Some more text.

![Block Image](/block.jpg)
{.blue}
```

The images in the above Markdown example would, given the hook template below, be rendered wrapped in a `figure` element with the `blue` CSS class applied in the latter example.

```handlebars
{{ if .IsBlock }}<figure class="{{ .Attributes.class }}"><img src="{{ .Destination | safeURL }}" alt="{{ .Text }}" /></figure>
{{ else }}<img src="{{ .Destination | safeURL }}" alt="{{ .Text }}" />{{ end }}
```

Two new fields are added to the render context passed to image render hooks:

* `IsBlock`: Returns true if this is a standalone image and the config option [markup.goldmark.parser.wrapStandAloneImageWithinParagraph](https://gohugo.io/getting-started/configuration-markup/#goldmark) is disabled.
* `Ordinal`: Zero-based ordinal for all the images in the current document.

## Bug fixes

* common/hugio: Fix multiWriteCloser.Close 5067775a @bep #10505 
* tpl/collections: Fix some index cases where the indices given is a slice and be more lenient with nil inputs d373774c @bep #10489 

## Improvements

* Make the hugo env non verbose output slightly more verbose f97544a8 @bep 
* Add dart-sass-embedded version info to hugo env -v d8efe085 @bep 
* tpl/embedded: Make Open Graph's series optional b82b547a @razonyang 
* dartsass: Add sourceMapIncludeSources option e93138df @bep 
* github: Update Dart Sass Embedded to 1.56.1 7d16c3c0 @bep 
* markup/goldmark: Add removeSurroundingParagraph for Markdown images 63126c63 @bep #8362 #10492 #10494 #10501 
* tpl/tplimpl: Allow alternate comment syntax 0b976d2b @jmooring #10495 
* resources: Increase timeout for http.Client a49e51fd @dirtymew #10478 
* config/security: Add CI env var to whitelist dc44bca9 @septs 
* tpl: Use consistent delimiter spacing in examples b8d5c378 @jmooring 

## Dependency Updates

* deps: Upgrade github.com/bep/godartsass v0.15.0 => v0.16.0 f5b5b71c @bep 
* build(deps): bump github.com/getkin/kin-openapi from 0.109.0 to 0.110.0 50549c86 @dependabot[bot] 
* build(deps): bump github.com/evanw/esbuild from 0.15.16 to 0.15.18 535ea8cc @dependabot[bot] 
* build(deps): bump golang.org/x/text from 0.4.0 to 0.5.0 8bbec426 @dependabot[bot] 
* build(deps): bump github.com/evanw/esbuild from 0.15.15 to 0.15.16 0bfa293d @dependabot[bot] 
* deps: Upgrade github.com/bep/godartsass v0.14.0 => v0.15.0 83080df6 @bep 

## Documentation

* docs: Add basic doc for wrapStandAloneImageWithinParagraph etc. de9c5542 @bep #10492 
* tpl: Misco GoDoc improvements 7d5e3ab8 @bep 
* docs: Regen docs helper 75f782a5 @bep 


