### PR TITLE
[hugo-updater] Update Hugo to version 0.116.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,5 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.115.4"
+  HUGO_VERSION = "0.116.0"
 


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.116.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.116.0

There are two notable changes in this release. For one, we have changed the default location of the `cacheDir` (where Hugo stores all its file caches). Having the cache stored in a `/tmp` folder has had its issues, especially for the module cache and especially on MacOS. The current new default should be better and more stable. See See  [Configure CacheDir](https://gohugo.io/getting-started/configuration/#configure-cachedir) for more info.

Also in this release: The `where` template func finally supports regular expressions with the new [like](https://gohugo.io/functions/where/#use-where-with-like) operator.

## Note

* Deprecate taxonomyTerm bec9b80d9 @bep #11256 
* Warn about unknown kinds in disableKinds 1c97095ac @bep #11256 
* The default value for `cacheDir` is changed to be stored below the directory as defined by  Go's [os.UserCacheDir](https://pkg.go.dev/os#UserCacheDir). See  [Configure CacheDir](https://gohugo.io/getting-started/configuration/#configure-cachedir)

## Bug fixes

* resources: Fix spelling in method name be8e2de59 @bep 
* Fix so temporary images do not get published fbb8eb39e @bep #10255 
* readme: Fix link 87d9bffe7 @tfsojon 
* tpl/collections: Fix description of apply function dc2a544fa @jmooring 
* Fix multiple languages in HUGO_DISABLELANGUAGES 7f058b8ba @bep #11278 

## Improvements

* config: Do not fail on unknown config keys c1df5b1b0 @bep 
* commands: Update cacheDir description d9fdcbe93 @jmooring 
* Update where.md 295d73388 @bep 
* Deprecate taxonomyTerm bec9b80d9 @bep #11256 
* Warn about unknown kinds in disableKinds 1c97095ac @bep #11256 
* Move all Kind constants to its own package b3cb6788b @bep #11256 
* Remove unused autogenerated method 36b512605 @bep 
* tpl/collections: Add BenchmarkWhereOps ef6e813ca @bep 
* tpl/collections: Add like operator to where function f4598a098 @jmooring #11279 
* Use os.UserCacheDir as first fallback if cacheDir is not set b3f10556f @bep #11286 #11291 
* Add a common regexp cache 4d7af757c @bep 
* commands: Replace deprecated ioutil with os 2589b1295 @alexandear 

## Dependency Updates

* build(deps): bump github.com/evanw/esbuild from 0.18.11 to 0.18.17 d7db096a9 @dependabot[bot] 
* build(deps): bump github.com/rogpeppe/go-internal 5542f02fb @dependabot[bot] 
* build(deps): bump golang.org/x/image from 0.8.0 to 0.9.0 0bc7ed9a1 @dependabot[bot] 
* deps: Upgrade github.com/yuin/goldmark v1.5.4 => v1.5.5 739d10e8b @jmooring 

## Documentation

* docs: Regenerate CLI docs d297c8e1b @bep 
* docs: Update where d5247788e @bep 
* docs: Update where function operators 036e260d8 @jmooring 
* docs: Rework the cacheDir documentation a50356b9a @bep 

## Build Setup

* snap: Set cache location to $HOME/.cache/hugo_cache 916397320 @jmooring 
* snap: Allow access to SSH keys and $HOME/.config/hugo 575d7f806 @jmooring #11288 


