### PR TITLE
[hugo-updater] Update Hugo to version 0.118.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,5 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.117.0"
+  HUGO_VERSION = "0.118.2"
 


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.118.2
More details in https://github.com/gohugoio/hugo/releases/tag/v0.118.2

## What's Changed

* release: Revert to building with Go 1.20 df5d76fed @bep #11414 


