### PR TITLE
[hugo-updater] Update Hugo to version 0.120.4

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,5 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.120.3"
+  HUGO_VERSION = "0.120.4"
 


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.120.4
More details in https://github.com/gohugoio/hugo/releases/tag/v0.120.4

The only change in this release is that the release binaries are compiled with Go 1.21.4 which comes with a security fix for Windows that may be relevant for Hugo. See:

* https://github.com/golang/go/issues?q=milestone%3AGo1.21.4+label%3ACherryPickApproved
* Especially golang/go#63715

## What's Changed

* Upgrade to go 1.21.4 9315a2d2c @bep #11685 


