### PR TITLE
[hugo-updater] Update Hugo to version 0.125.4

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,5 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.125.2"
+  HUGO_VERSION = "0.125.4"
 


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.125.4
More details in https://github.com/gohugoio/hugo/releases/tag/v0.125.4

## What Changed

* Fix rebuilds when running hugo -w 7203a95a6 @bep #12296 
* tpl/tplimpl: Fix double-escaping in opengraph template fb51b698b @jmooring #12418 
* commands: Clarify that create or install a theme are two options fe84cc218 @Habbie 
* config: Setups with only one active language can never be multihost babcb339a @bep #12288 
* Use Apache License without modification 6b867972e @bep #12415 
* build(deps): bump github.com/tdewolff/minify/v2 from 2.20.19 to 2.20.20 fb084390c @dependabot[bot] 


