### PR TITLE
[hugo-updater] Update Hugo to version 0.125.6

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,5 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.125.2"
+  HUGO_VERSION = "0.125.6"
 


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.125.6
More details in https://github.com/gohugoio/hugo/releases/tag/v0.125.6

## What's Changed

* Fix one more resource change eviction logic issue bb59a7ed9 @bep #12395 #12456 
* Make the cache eviction logic for stale entities more robust 503d20954 @bep #12458 
* build(deps): bump github.com/pelletier/go-toml/v2 from 2.2.1 to 2.2.2 68e95327f @dependabot[bot] 
* Run mage generate 9cd7db61d @bep 
* resources/page: Pull internal Page methods into its own interface c892e75fb @bep 


