### PR TITLE
[hugo-updater] Update Hugo to version 0.125.7

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,5 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.125.2"
+  HUGO_VERSION = "0.125.7"
 


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.125.7
More details in https://github.com/gohugoio/hugo/releases/tag/v0.125.7

**Note** that this release is only relevant if you use Hugo's `openapi3.Unmarshal` template function.

## What's Changed

* deps: Downgrade github.com/getkin/kin-openapi v0.124.0 => v0.123.0 3c6260f04 @bep 


