### PR TITLE
[hugo-updater] Update Hugo to version 0.126.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,5 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.125.2"
+  HUGO_VERSION = "0.126.1"
 


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.126.1
More details in https://github.com/gohugoio/hugo/releases/tag/v0.126.1

## What's Changed

* Fix mixed case Page params handling in content adapters 39cf906bc @bep #12497 
* Fix paths with dots issue with content adapters 1aacfced3 @bep #12493 


