### PR TITLE
[hugo-updater] Update Hugo to version 0.128.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,5 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.127.0"
+  HUGO_VERSION = "0.128.0"
 


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.128.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.128.0

