### PR TITLE
feat: modernize the meetup website design

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,48 @@
+name: Playwright tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Set up Hugo
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3
+        with:
+          hugo-version: '0.163.3'
+          extended: true
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium webkit
+
+      - name: Run responsive browser tests
+        run: npm test
+
+      - name: Upload test report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules/
 .env.prod
 public/
+playwright-report/
+test-results/

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # https://suva.sh/posts/well-documented-makefiles/#simple-makefile
-.DEFAULT_GOAL:=help
-SHELL:=/bin/bash
+.DEFAULT_GOAL := help
+SHELL := /bin/bash
 
 TITLE := $(shell echo $(name) | tr [:upper:] [:lower:] | sed -e 's/ /_/g')
 
-.PHONY: help deps clean build watch
+.PHONY: help deps clean build watch test
 
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -14,6 +14,9 @@ build: ## Build the project
 
 watch: ## Watch file changes and build
 	hugo server -w
+
+test: ## Run responsive Playwright tests before pushing
+	npm test
 
 post: ## Make new post: make post name="Title"
 	hugo new  --kind post post/`date +%Y-%m-%d`-$(TITLE).markdown

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = 'http://hugo-quickstart-template.netlify.com'
-languageCode = 'en-us'
+baseURL = 'https://www.gomeetupprague.cz/'
+locale = 'en-US'
 title = 'Go Meetup Prague'
 theme = 'netlify-basic'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "gomeetupprague-website",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gomeetupprague-website",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.62.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "gomeetupprague-website",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.62.1"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'desktop-chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'android-pixel-7',
+      use: { ...devices['Pixel 7'] },
+    },
+    {
+      name: 'iphone-13',
+      use: { ...devices['iPhone 13'] },
+    },
+  ],
+  webServer: {
+    command: 'hugo server --bind 127.0.0.1 --port 4173 --disableFastRender',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test'
+
+const externalDestinations = {
+  meetup: 'https://www.meetup.com/prague-golang-meetup/',
+  slack: 'https://invite.slack.golangbridge.org/',
+  mastodon: 'https://fosstodon.org/@gomeetupprague',
+  youtube: 'https://www.youtube.com/@gomeetupprague',
+  anniversary: 'https://10years.gomeetupprague.cz/',
+}
+
+test.beforeEach(async ({ page }) => {
+  // The application is static. Blocking third-party requests keeps the suite
+  // deterministic while still allowing every external destination to be checked.
+  await page.route(/^https:\/\//, (route) => route.abort())
+})
+
+test('homepage exposes every primary community action', async ({ page }) => {
+  const response = await page.goto('/')
+
+  expect(response?.ok()).toBeTruthy()
+  await expect(page).toHaveTitle('Go Meetup Prague')
+  await expect(page.getByRole('heading', { level: 1 })).toContainText(
+    'Build better software.',
+  )
+  await expect(page.getByRole('link', { name: /join the next meetup/i })).toHaveAttribute(
+    'href',
+    externalDestinations.meetup,
+  )
+  await expect(page.getByRole('link', { name: /meet us in/i })).toHaveAttribute(
+    'href',
+    externalDestinations.slack,
+  )
+  await expect(page.getByRole('heading', { name: 'Take the stage.' })).toBeVisible()
+
+  const footer = page.getByRole('contentinfo')
+  await expect(footer.getByRole('link', { name: 'Mastodon' })).toHaveAttribute(
+    'href',
+    externalDestinations.mastodon,
+  )
+  await expect(footer.getByRole('link', { name: 'YouTube' })).toHaveAttribute(
+    'href',
+    externalDestinations.youtube,
+  )
+  await expect(footer.getByRole('link', { name: '10 years' })).toHaveAttribute(
+    'href',
+    externalDestinations.anniversary,
+  )
+})
+
+test('navigation opens the complete video archive', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('link', { name: /watch past talks/i }).click()
+
+  await expect(page).toHaveURL(/\/videos\/$/)
+  await expect(page.getByRole('heading', { level: 1, name: 'Videos' })).toBeVisible()
+
+  const cards = page.locator('.video-card')
+  await expect(cards).toHaveCount(37)
+  await expect(cards.first().getByRole('heading', { level: 3 })).not.toBeEmpty()
+
+  const embeds = page.locator('.video-embed iframe')
+  await expect(embeds).toHaveCount(37)
+  expect(await embeds.evaluateAll((frames) => frames.every((frame) => frame.loading === 'lazy'))).toBe(
+    true,
+  )
+  expect(
+    await embeds.evaluateAll((frames) =>
+      frames.every((frame) => /^https:\/\/(www\.)?youtube\.com\/embed\//.test(frame.src)),
+    ),
+  ).toBe(true)
+})
+
+test('layout fits the active desktop or phone viewport', async ({ page, isMobile }) => {
+  await page.goto('/')
+
+  const viewport = page.viewportSize()
+  expect(viewport).not.toBeNull()
+  const documentWidth = await page.evaluate(() => document.documentElement.scrollWidth)
+  expect(documentWidth).toBeLessThanOrEqual(viewport.width + 1)
+
+  await expect(page.locator('.hero')).toBeVisible()
+  await expect(page.locator('.community-section')).toBeVisible()
+  await expect(page.locator('.speaker-callout')).toBeVisible()
+
+  const homeNavigation = page.getByRole('navigation').getByRole('link', { name: 'Home' })
+  if (isMobile) {
+    await expect(homeNavigation).toBeHidden()
+    await expect(page.getByRole('link', { name: /join the community/i })).toBeVisible()
+  } else {
+    await expect(homeNavigation).toBeVisible()
+  }
+})
+
+test('keyboard users can skip directly to the main content', async ({ page }) => {
+  await page.goto('/')
+  const skipLink = page.getByRole('link', { name: 'Skip to content' })
+  await skipLink.focus()
+  await expect(skipLink).toBeFocused()
+  await skipLink.press('Enter')
+  await expect(page.locator('#main-content')).toBeFocused()
+})

--- a/themes/netlify-basic/layouts/_default/baseof.html
+++ b/themes/netlify-basic/layouts/_default/baseof.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html>
-    {{- partial "head.html" . -}}
-    <body>
-        {{- partial "header.html" . -}}
-        <div id="content">
-        {{- block "main" . }}{{- end }}
-        </div>
-        {{- partial "footer.html" . -}}
-    </body>
+<html lang="{{ .Site.Language.Lang | default "en" }}">
+  {{- partial "head.html" . -}}
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    {{- partial "header.html" . -}}
+    <main id="main-content">
+      {{- block "main" . }}{{- end }}
+    </main>
+    {{- partial "footer.html" . -}}
+  </body>
 </html>

--- a/themes/netlify-basic/layouts/_default/baseof.html
+++ b/themes/netlify-basic/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
   <body>
     <a class="skip-link" href="#main-content">Skip to content</a>
     {{- partial "header.html" . -}}
-    <main id="main-content">
+    <main id="main-content" tabindex="-1">
       {{- block "main" . }}{{- end }}
     </main>
     {{- partial "footer.html" . -}}

--- a/themes/netlify-basic/layouts/index.html
+++ b/themes/netlify-basic/layouts/index.html
@@ -1,58 +1,125 @@
 {{ define "main" }}
-<svg id="background" width='1728' height='1235' viewBox="0 0 1728 1235" fill='none' xmlns='http://www.w3.org/2000/svg'>
-  <g opacity='0.75' filter='url(#filter0_f_39_143)'>
-    <circle cy='1000' r='264' fill='url(#paint0_linear_39_143)' />
-  </g>
-  <g opacity='0.65' filter='url(#filter1_f_39_143)'>
-    <circle cx='1720' cy='264' r='379' fill='url(#paint1_linear_39_143)' />
-  </g>
-  <defs>
-    <filter id='filter0_f_39_143' x='-485' y='515' width='970' height='970' filterUnits='userSpaceOnUse'
-      color-interpolation-filters='sRGB'>
-      <feFlood flood-opacity='0' result='BackgroundImageFix' />
-      <feBlend mode='normal' in='SourceGraphic' in2='BackgroundImageFix' result='shape' />
-      <feGaussianBlur stdDeviation='110.5' result='effect1_foregroundBlur_39_143' />
-    </filter>
-    <filter id='filter1_f_39_143' x='1120' y='-336' width='1200' height='1200' filterUnits='userSpaceOnUse'
-      color-interpolation-filters='sRGB'>
-      <feFlood flood-opacity='0' result='BackgroundImageFix' />
-      <feBlend mode='normal' in='SourceGraphic' in2='BackgroundImageFix' result='shape' />
-      <feGaussianBlur stdDeviation='110.5' result='effect1_foregroundBlur_39_143' />
-    </filter>
-    <linearGradient id='paint0_linear_39_143' x1='196.5' y1='902' x2='-2.55853e-05' y2='1264'
-      gradientUnits='userSpaceOnUse'>
-      <stop stop-color="var(--bttm-left-blur-1)" />
-      <stop offset='1' stop-color="var(--bttm-left-blur-2)" />
-    </linearGradient>
-    <linearGradient id='paint1_linear_39_143' x1='1720' y1='-115' x2='1720' y2='643' gradientUnits='userSpaceOnUse'>
-      <stop stop-color="var(--top-right-blur-1)" />
-      <stop offset='1' stop-color="var(--top-right-blur-2)" />
-    </linearGradient>
-  </defs>
-</svg>
-<div id="content">
-  <div class="header">
-    <h1>Go Meetup Prague</h1>
-    <div class="logo">
-      <img src="https://res.cloudinary.com/abtris/image/upload/v1667935543/gopher_mu2bb9.png" alt="gopher logo"
-        role="presentation">
-    </div>
-    <h2>
-      A meetup group to discuss the Go Programming Language.
-    </h2>
-    <div class="invite">
-      <p>If you have suggestions or you want talk on meetup, <a rel="me" href="https://hachyderm.io/@abtris">contact
-          me on Mastodon</a> or please use <a href="https://invite.slack.golangbridge.org/">Gopher's slack</a>
-        <code>#prague-meetup</code> channel.
+<section class="hero">
+  <div class="hero-glow hero-glow-one" aria-hidden="true"></div>
+  <div class="hero-glow hero-glow-two" aria-hidden="true"></div>
+  <div class="hero-grid" aria-hidden="true"></div>
+
+  <div class="shell hero-layout">
+    <div class="hero-copy">
+      <div class="eyebrow"><span></span> Prague’s Go community</div>
+      <h1>Build better software.<br /><em>Together.</em></h1>
+      <p class="hero-lead">
+        A friendly meetup for people who build with Go—or simply want to. Hear
+        honest stories, discover new ideas, and meet the people behind the code.
       </p>
+      <div class="hero-actions">
+        <a
+          href="https://www.meetup.com/prague-golang-meetup/"
+          class="button button-primary"
+          >Join the next meetup <span aria-hidden="true">↗</span></a
+        >
+        <a href="/videos/" class="button button-secondary"
+          ><span class="play" aria-hidden="true">▶</span> Watch past talks</a
+        >
+      </div>
+      <div class="hero-note">
+        <span class="avatar-stack" aria-hidden="true"
+          ><i>G</i><i>{ }</i><i>go</i></span
+        >
+        <span>Developers, speakers &amp; curious minds welcome</span>
+      </div>
     </div>
-    <div class="bttns">
-      <a href="https://www.meetup.com/prague-golang-meetup/" class="bttn primary">Join our Meetup group</a>
-      <a href="https://fosstodon.org/@gomeetupprague" rel="me" class="bttn primary">Follow us on Mastodon</a>
-      <a href="https://www.youtube.com/@gomeetupprague" class="bttn primary">Subscribe to our Youtube channel</a>
-      <a href="/videos/" class="bttn primary">Watch Videos</a>
-      <a href="https://10years.gomeetupprague.cz/" class="bttn primary">10 Years Anniversary</a>
+
+    <div
+      class="hero-visual"
+      aria-label="The Go gopher, mascot of the Go programming language"
+    >
+      <div class="orbit orbit-one"></div>
+      <div class="orbit orbit-two"></div>
+      <span class="floating-chip chip-one">go func()</span>
+      <span class="floating-chip chip-two"
+        >Prague<br /><strong>50.0755° N</strong></span
+      >
+      <div class="gopher-card">
+        <span class="card-label">Community powered</span>
+        <img
+          src="https://res.cloudinary.com/abtris/image/upload/v1667935543/gopher_mu2bb9.png"
+          alt="Go gopher mascot"
+        />
+        <div class="code-line"><span>package</span> community</div>
+      </div>
     </div>
   </div>
-</div>
+</section>
+
+<section class="stats" aria-label="Community highlights">
+  <div class="shell stats-grid">
+    <div class="stat"><strong>37+</strong><span>talks to watch</span></div>
+    <div class="stat"><strong>5</strong><span>seasons archived</span></div>
+    <div class="stat"><strong>100%</strong><span>community driven</span></div>
+    <div class="stat stat-message">
+      <span class="status-dot"></span
+      ><span>New Go friends are always welcome.</span>
+    </div>
+  </div>
+</section>
+
+<section class="community-section">
+  <div class="shell community-grid">
+    <div class="section-copy">
+      <div class="eyebrow eyebrow-dark"><span></span> More than code</div>
+      <h2>Learn something.<br />Share something.</h2>
+      <p>
+        Whether it’s your first meetup or your fiftieth, this is a place to
+        exchange practical knowledge without the hype. Come for the talks, stay
+        for the conversations.
+      </p>
+      <a class="text-link" href="https://invite.slack.golangbridge.org/"
+        >Meet us in <code>#prague-meetup</code>
+        <span aria-hidden="true">→</span></a
+      >
+    </div>
+    <div class="community-cards">
+      <a
+        class="feature-card feature-card-cyan"
+        href="https://www.meetup.com/prague-golang-meetup/"
+      >
+        <span class="feature-number">01</span>
+        <span class="feature-icon" aria-hidden="true">⌁</span>
+        <h3>Meet in Prague</h3>
+        <p>
+          Regular evenings of practical talks, open discussion, and friendly
+          networking.
+        </p>
+        <span class="card-arrow" aria-hidden="true">↗</span>
+      </a>
+      <a class="feature-card" href="https://www.youtube.com/@gomeetupprague">
+        <span class="feature-number">02</span>
+        <span class="feature-icon" aria-hidden="true">▷</span>
+        <h3>Learn anywhere</h3>
+        <p>
+          Catch up on technical sessions and community stories from our video
+          archive.
+        </p>
+        <span class="card-arrow" aria-hidden="true">↗</span>
+      </a>
+    </div>
+  </div>
+</section>
+
+<section class="speaker-callout">
+  <div class="shell callout-inner">
+    <div>
+      <span class="callout-kicker">Have a story to tell?</span>
+      <h2>Take the stage.</h2>
+    </div>
+    <p>
+      First-time speakers are especially welcome. Bring an idea, a lesson
+      learned, or a project you’re proud of.
+    </p>
+    <a class="button button-light" rel="me" href="https://hachyderm.io/@abtris"
+      >Pitch your talk <span aria-hidden="true">↗</span></a
+    >
+  </div>
+</section>
 {{ end }}

--- a/themes/netlify-basic/layouts/partials/footer.html
+++ b/themes/netlify-basic/layouts/partials/footer.html
@@ -1,3 +1,26 @@
-<footer>
-  <p>Made with <a href="https://ntl.fyi/3P0dwBi"><img src="https://res.cloudinary.com/dzkoxrsdj/image/upload/v1646714899/netliheart_ezlkim.svg" alt="Netlify Logo" class="footer-icon"/></a> for you!</p>
+<footer class="site-footer">
+  <div class="shell footer-grid">
+    <div>
+      <a class="brand footer-brand" href="/" aria-label="Go Meetup Prague home">
+        <span class="brand-mark" aria-hidden="true">Go</span>
+        <span class="brand-name">Meetup <strong>Prague</strong></span>
+      </a>
+      <p>Good code. Great people.<br />Right here in Prague.</p>
+    </div>
+    <div class="footer-links">
+      <div>
+        <span>Explore</span><a href="/videos/">Videos</a
+        ><a href="https://www.meetup.com/prague-golang-meetup/">Meetup</a>
+      </div>
+      <div>
+        <span>Follow</span
+        ><a rel="me" href="https://fosstodon.org/@gomeetupprague">Mastodon</a
+        ><a href="https://www.youtube.com/@gomeetupprague">YouTube</a>
+      </div>
+    </div>
+  </div>
+  <div class="shell footer-bottom">
+    <span>© {{ now.Year }} Go Meetup Prague</span>
+    <span>Made by the community, for the community.</span>
+  </div>
 </footer>

--- a/themes/netlify-basic/layouts/partials/footer.html
+++ b/themes/netlify-basic/layouts/partials/footer.html
@@ -10,7 +10,8 @@
     <div class="footer-links">
       <div>
         <span>Explore</span><a href="/videos/">Videos</a
-        ><a href="https://www.meetup.com/prague-golang-meetup/">Meetup</a>
+        ><a href="https://www.meetup.com/prague-golang-meetup/">Meetup</a
+        ><a href="https://10years.gomeetupprague.cz/">10 years</a>
       </div>
       <div>
         <span>Follow</span

--- a/themes/netlify-basic/layouts/partials/head.html
+++ b/themes/netlify-basic/layouts/partials/head.html
@@ -1,17 +1,32 @@
 <head>
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-YSSWY872LM"></script>
+  <script
+    async
+    src="https://www.googletagmanager.com/gtag/js?id=G-YSSWY872LM"
+  ></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
+    function gtag() {
+      dataLayer.push(arguments);
+    }
     gtag('js', new Date());
-
     gtag('config', 'G-YSSWY872LM');
-  </script>  
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" type="text/css" href="/css/demo-styling.css">
-  {{ $title := print .Site.Title " | " .Title }}
-  {{ if .IsHome }}{{ $title = .Site.Title }}{{ end }}
-  <title>{{ $title }}</title>  
+  </script>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#07191f" />
+  <meta
+    name="description"
+    content="Prague's community for Go developers—meetups, talks, and conversations about the Go programming language."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap"
+  />
+  <link rel="stylesheet" href="/css/demo-styling.css" />
+  {{ $title := print .Site.Title " | " .Title }} {{ if .IsHome }}{{ $title =
+  .Site.Title }}{{ end }}
+  <title>{{ $title }}</title>
 </head>

--- a/themes/netlify-basic/layouts/partials/header.html
+++ b/themes/netlify-basic/layouts/partials/header.html
@@ -1,0 +1,13 @@
+<header class="site-header">
+  <div class="nav-shell">
+    <a class="brand" href="/" aria-label="Go Meetup Prague home">
+      <span class="brand-mark" aria-hidden="true">Go</span>
+      <span class="brand-name">Meetup <strong>Prague</strong></span>
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/"{{ if .IsHome }} aria-current="page"{{ end }}>Home</a>
+      <a href="/videos/"{{ if eq .Section "videos" }} aria-current="page"{{ end }}>Videos</a>
+      <a class="nav-cta" href="https://www.meetup.com/prague-golang-meetup/">Join the community <span aria-hidden="true">↗</span></a>
+    </nav>
+  </div>
+</header>

--- a/themes/netlify-basic/layouts/videos/list.html
+++ b/themes/netlify-basic/layouts/videos/list.html
@@ -8,32 +8,47 @@
   <div class="videos-content">
     <p class="videos-info">
       Videos from our Go Meetup Prague events. You can also
-      <a href="https://www.youtube.com/@gomeetupprague" target="_blank" rel="noopener noreferrer">
+      <a
+        href="https://www.youtube.com/@gomeetupprague"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         subscribe to our YouTube channel
       </a>
       for the latest content.
     </p>
 
-    {{ $videos := .Site.Data.videos }}
-    {{ range $videos.years }}
-      <div class="meetup-group">
-        <h2>{{ .year }}</h2>
-        <div class="videos-grid">
-          {{ range .videos }}
-            <div class="video-card">
-              <div class="video-embed">
-                <iframe width="100%" height="315" src="{{ .url }}"
-                  title="{{ .title }}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                  allowfullscreen></iframe>
-              </div>
-              <h3>{{ .title }}</h3>
-              <p class="video-speaker">{{ .published }}</p>
-            </div>
-          {{ end }}
-        </div>
+    {{ $videos := hugo.Data.videos }} {{ range $videos.years }}
+    <div class="meetup-group">
+      <h2>{{ .year }}</h2>
+      <div class="videos-grid">
+        {{ range .videos }}
+        <article class="video-card">
+          <div class="video-embed">
+            <iframe
+              width="100%"
+              height="315"
+              src="{{ .url }}"
+              title="{{ .title }}"
+              loading="lazy"
+              allow="
+                accelerometer;
+                autoplay;
+                clipboard-write;
+                encrypted-media;
+                gyroscope;
+                picture-in-picture;
+              "
+              allowfullscreen
+            ></iframe>
+          </div>
+          <h3>{{ .title }}</h3>
+          <p class="video-speaker">{{ .published }}</p>
+        </article>
+        {{ end }}
       </div>
+    </div>
     {{ end }}
   </div>
 </div>
 {{ end }}
-

--- a/themes/netlify-basic/static/css/demo-styling.css
+++ b/themes/netlify-basic/static/css/demo-styling.css
@@ -1,271 +1,913 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap');
 
 :root {
-  --main-family: 'Poppins', sans-serif;
-  --color-bg: linear-gradient(180deg, #FFFFFF 0%, #AEC6DC 100%);
-
-  /* Controls the blob blur gradient colors within the main tag's svg */
-  --top-right-blur-1: #2ebc92;
-  --top-right-blur-2: #ecbb50;
-  --bttm-left-blur-1: #ff3e89;
-  --bttm-left-blur-2: #0095cc;
+  --ink: #07191f;
+  --ink-soft: #123039;
+  --paper: #f4f7f5;
+  --white: #fff;
+  --cyan: #55d9e8;
+  --cyan-bright: #7de7f0;
+  --coral: #ff6b58;
+  --muted: #a8bbc0;
+  --line: rgba(255, 255, 255, 0.13);
+  --font-body: 'DM Sans', sans-serif;
+  --font-display: 'Space Grotesk', sans-serif;
+  --font-code: 'DM Mono', monospace;
 }
 
+* {
+  box-sizing: border-box;
+}
 html {
-    background: var(--color-bg);
-    font-family: var(--main-family);
-    min-height: 100%;
+  scroll-behavior: smooth;
 }
-
-body{
+body {
   margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-body);
+  -webkit-font-smoothing: antialiased;
+}
+a {
+  color: inherit;
+}
+img {
+  max-width: 100%;
+}
+.shell {
+  width: min(1180px, calc(100% - 48px));
+  margin-inline: auto;
+}
+.skip-link {
+  position: fixed;
+  z-index: 100;
+  top: 8px;
+  left: 8px;
+  padding: 10px 16px;
+  background: var(--white);
+  color: var(--ink);
+  transform: translateY(-150%);
+}
+.skip-link:focus {
+  transform: none;
 }
 
-#background {
-    position: fixed;
-    width: 100%;
-    z-index: -1;
-    height: 100%;
+/* Navigation */
+.site-header {
+  position: relative;
+  z-index: 10;
+  background: var(--ink);
+  color: var(--white);
+  border-bottom: 1px solid var(--line);
+}
+.nav-shell {
+  width: min(1180px, calc(100% - 48px));
+  min-height: 82px;
+  margin-inline: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 32px;
+}
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 11px;
+  color: var(--white);
+  text-decoration: none;
+}
+.brand-mark {
+  width: 43px;
+  height: 43px;
+  display: grid;
+  place-items: center;
+  border-radius: 50% 50% 45% 48%;
+  background: var(--cyan);
+  color: var(--ink);
+  font: 700 17px/1 var(--font-display);
+  transform: rotate(-5deg);
+}
+.brand-name {
+  font: 500 16px/1 var(--font-display);
+  letter-spacing: -0.02em;
+}
+.brand-name strong {
+  display: block;
+  color: var(--cyan);
+  font-weight: 600;
+}
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 35px;
+  font-size: 14px;
+  font-weight: 600;
+}
+.site-nav a {
+  text-decoration: none;
+  color: #c6d2d5;
+  transition: color 0.2s ease;
+}
+.site-nav a:hover,
+.site-nav a[aria-current='page'] {
+  color: var(--white);
+}
+.site-nav .nav-cta {
+  padding: 11px 16px;
+  border: 1px solid rgba(125, 231, 240, 0.42);
+  border-radius: 999px;
+  color: var(--cyan-bright);
+}
+.site-nav .nav-cta:hover {
+  background: var(--cyan);
+  border-color: var(--cyan);
+  color: var(--ink);
 }
 
-#content {
+/* Hero */
+.hero {
+  position: relative;
+  overflow: hidden;
+  min-height: 690px;
+  background: var(--ink);
+  color: var(--white);
+}
+.hero-grid {
+  position: absolute;
+  inset: 0;
+  opacity: 0.2;
+  background-image:
+    linear-gradient(rgba(125, 231, 240, 0.13) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(125, 231, 240, 0.13) 1px, transparent 1px);
+  background-size: 68px 68px;
+  mask-image: linear-gradient(to right, transparent 4%, black 42%, black 100%);
+}
+.hero-glow {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(2px);
+  pointer-events: none;
+}
+.hero-glow-one {
+  width: 540px;
+  height: 540px;
+  top: 0;
+  right: 4%;
+  background: radial-gradient(circle, rgba(41, 181, 195, 0.2), transparent 66%);
+}
+.hero-glow-two {
+  width: 280px;
+  height: 280px;
+  left: -150px;
+  bottom: -80px;
+  background: rgba(255, 107, 88, 0.12);
+  filter: blur(75px);
+}
+.hero-layout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1.08fr 0.92fr;
+  align-items: center;
+  gap: 70px;
+  min-height: 690px;
+  padding-block: 70px 90px;
+}
+.eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--cyan-bright);
+  font: 500 12px/1 var(--font-code);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.eyebrow span {
+  width: 27px;
+  height: 2px;
+  background: var(--coral);
+}
+.hero h1 {
+  max-width: 700px;
+  margin: 25px 0 24px;
+  font: 600 clamp(54px, 6.3vw, 91px)/0.98 var(--font-display);
+  letter-spacing: -0.065em;
+}
+.hero h1 em {
+  color: var(--cyan);
+  font-style: normal;
+}
+.hero-lead {
+  max-width: 610px;
+  margin: 0;
+  color: #b7c8cc;
+  font-size: 18px;
+  line-height: 1.65;
+}
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 13px;
+  margin-top: 34px;
+}
+.button {
+  min-height: 52px;
+  padding: 0 21px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border-radius: 6px;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 700;
+  transition:
+    transform 0.2s ease,
+    background 0.2s ease,
+    box-shadow 0.2s ease;
+}
+.button:hover {
+  transform: translateY(-2px);
+}
+.button-primary {
+  background: var(--coral);
+  color: var(--white);
+  box-shadow: 0 12px 30px rgba(255, 107, 88, 0.2);
+}
+.button-primary:hover {
+  background: #ff7c6b;
+}
+.button-secondary {
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  color: var(--white);
+}
+.button-secondary:hover {
+  border-color: var(--cyan);
+  background: rgba(85, 217, 232, 0.08);
+}
+.play {
+  color: var(--cyan);
+  font-size: 11px;
+}
+.hero-note {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  margin-top: 32px;
+  color: #91a8ad;
+  font-size: 12px;
+}
+.avatar-stack {
+  display: flex;
+  padding-left: 7px;
+}
+.avatar-stack i {
+  width: 30px;
+  height: 30px;
+  margin-left: -7px;
+  display: grid;
+  place-items: center;
+  border: 2px solid var(--ink);
+  border-radius: 50%;
+  background: #244550;
+  color: var(--cyan);
+  font: 500 9px/1 var(--font-code);
+  font-style: normal;
+}
+.avatar-stack i:nth-child(2) {
+  background: var(--coral);
+  color: white;
+}
+.avatar-stack i:nth-child(3) {
+  background: var(--cyan);
+  color: var(--ink);
+}
+
+.hero-visual {
+  position: relative;
+  min-height: 485px;
+  display: grid;
+  place-items: center;
+}
+.gopher-card {
+  position: relative;
+  z-index: 2;
+  width: min(350px, 85%);
+  min-height: 420px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 0 auto;
+  justify-content: center;
+  overflow: hidden;
+  border: 1px solid rgba(125, 231, 240, 0.25);
+  border-radius: 42% 42% 22px 22px;
+  background: linear-gradient(
+    160deg,
+    rgba(71, 173, 184, 0.2),
+    rgba(8, 32, 39, 0.85)
+  );
+  box-shadow:
+    0 30px 100px rgba(0, 0, 0, 0.35),
+    inset 0 1px rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
 }
-
-.header{
-    text-align: center;
+.gopher-card::before {
+  content: '';
+  position: absolute;
+  width: 250px;
+  height: 250px;
+  border-radius: 50%;
+  background: var(--cyan);
+  opacity: 0.12;
+  filter: blur(30px);
 }
-
-.header h1 {
-  padding-top:5%;
-  margin: 0;
-  font-size: calc(max(5vw, 32px));
+.gopher-card img {
+  position: relative;
+  z-index: 1;
+  width: 84%;
+  filter: drop-shadow(0 22px 22px rgba(0, 0, 0, 0.25));
 }
-
-.header .logo img {
-  padding: 30px 0;
-  width: 50%;
+.card-label {
+  position: absolute;
+  top: 30px;
+  color: #a9c5ca;
+  font: 500 10px/1 var(--font-code);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
 }
-
-.header h2 {
-  line-height: 34px;
-  width: 50%;
-  margin: 0 auto;
-  padding-bottom: 5%;
+.code-line {
+  position: absolute;
+  z-index: 2;
+  bottom: 21px;
+  padding: 10px 15px;
+  border-radius: 5px;
+  background: rgba(4, 18, 23, 0.72);
+  color: #dbe8ea;
+  font: 400 11px/1 var(--font-code);
+}
+.code-line span {
+  color: var(--coral);
+}
+.orbit {
+  position: absolute;
+  border: 1px solid rgba(125, 231, 240, 0.18);
+  border-radius: 50%;
+  transform: rotate(-24deg);
+}
+.orbit-one {
+  width: 465px;
+  height: 270px;
+}
+.orbit-two {
+  width: 390px;
+  height: 475px;
+  transform: rotate(32deg);
+}
+.floating-chip {
+  position: absolute;
+  z-index: 3;
+  padding: 11px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 5px;
+  background: rgba(7, 25, 31, 0.88);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.22);
+  color: var(--cyan-bright);
+  font: 500 10px/1.45 var(--font-code);
+}
+.chip-one {
+  left: -6px;
+  top: 30%;
+  transform: rotate(-4deg);
+}
+.chip-two {
+  right: -5px;
+  bottom: 24%;
+  color: #b6c9cd;
+}
+.chip-two strong {
+  color: var(--white);
   font-weight: 500;
 }
 
-
-@media only screen and (max-width: 450px) {
-  .header h2 {
-    width: 90%;
-    padding: 5%;
-  }
+/* Stats */
+.stats {
+  position: relative;
+  z-index: 3;
+  margin-top: -1px;
+  background: var(--cyan);
+  color: var(--ink);
 }
-
-.invite code {
-  font-size: 1.2em !important;
+.stats-grid {
+  min-height: 108px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr) 1.55fr;
+  align-items: stretch;
 }
-
-.bttns{
-  margin-bottom: 5%;
+.stat {
+  padding: 25px 29px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border-right: 1px solid rgba(7, 25, 31, 0.16);
 }
-
-.bttn{
-  padding: 15px;
-  border-radius: 5px;
-  width: 150px;
-  margin: 0 1%;
-  text-decoration: none;
+.stat:first-child {
+  border-left: 1px solid rgba(7, 25, 31, 0.16);
 }
-
-.bttn.primary{
-  margin-top: 10px;
-  display: inline-block;
-  width: max-content;
-  background: #21A69A;
-  border: none;
-  color: white;
-  box-shadow: -3px 3px 5px rgb(35 33 33 / 23%);
+.stat strong {
+  font: 700 26px/1 var(--font-display);
+  letter-spacing: -0.04em;
 }
-
-/* Videos Page Styles */
-.videos-container {
-  width: 100%;
-  max-width: 1200px;
-  padding: 40px 20px;
-  margin: 0 auto;
+.stat > span {
+  margin-top: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
-
-.videos-header {
-  text-align: center;
-  margin-bottom: 40px;
+.stat-message {
+  flex-direction: row;
+  align-items: center;
+  gap: 11px;
+  border-right: 1px solid rgba(7, 25, 31, 0.16);
 }
-
-.videos-header h1 {
-  font-size: 2.5em;
-  margin-bottom: 10px;
-  color: #333;
-}
-
-.videos-header p {
-  font-size: 1.1em;
-  color: #666;
+.stat-message > span {
   margin: 0;
+  font-size: 12px;
+}
+.status-dot {
+  flex: 0 0 auto;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--coral);
+  box-shadow: 0 0 0 5px rgba(255, 107, 88, 0.2);
 }
 
-.videos-content {
-  width: 100%;
+/* Community */
+.community-section {
+  padding: 120px 0;
+  background: var(--paper);
 }
-
-.videos-info {
-  text-align: center;
-  font-size: 1.05em;
-  color: #555;
-  margin-bottom: 40px;
-  padding: 20px;
-  background: rgba(33, 166, 154, 0.1);
-  border-radius: 8px;
+.community-grid {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: clamp(50px, 8vw, 115px);
+  align-items: center;
 }
-
-.videos-info a {
-  color: #21A69A;
+.eyebrow-dark {
+  color: #2c727c;
+}
+.section-copy h2 {
+  margin: 23px 0;
+  font: 600 clamp(39px, 4.3vw, 60px)/1.05 var(--font-display);
+  letter-spacing: -0.055em;
+}
+.section-copy p {
+  color: #536a70;
+  font-size: 16px;
+  line-height: 1.75;
+}
+.text-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 19px;
+  color: var(--ink);
   text-decoration: none;
-  font-weight: 600;
+  font-weight: 700;
+  border-bottom: 2px solid var(--cyan);
+  padding-bottom: 5px;
+}
+.text-link code {
+  font: inherit;
+}
+.text-link span {
+  color: var(--coral);
+}
+.community-cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+.feature-card {
+  position: relative;
+  min-height: 390px;
+  padding: 26px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  overflow: hidden;
+  border: 1px solid #dce5e2;
+  background: var(--white);
+  color: var(--ink);
+  text-decoration: none;
+  transition:
+    transform 0.25s ease,
+    box-shadow 0.25s ease;
+}
+.feature-card:hover {
+  transform: translateY(-7px);
+  box-shadow: 0 20px 55px rgba(7, 25, 31, 0.11);
+}
+.feature-card-cyan {
+  background: var(--cyan);
+  border-color: var(--cyan);
+}
+.feature-number {
+  position: absolute;
+  top: 25px;
+  left: 26px;
+  font: 500 10px/1 var(--font-code);
+  opacity: 0.55;
+}
+.feature-icon {
+  position: absolute;
+  top: 64px;
+  left: 26px;
+  font: 500 72px/1 var(--font-display);
+  color: #2297a5;
+}
+.feature-card:not(.feature-card-cyan) .feature-icon {
+  color: var(--coral);
+}
+.feature-card h3 {
+  margin: 0 0 12px;
+  font: 600 25px/1.1 var(--font-display);
+  letter-spacing: -0.04em;
+}
+.feature-card p {
+  margin: 0;
+  color: #3f6068;
+  font-size: 14px;
+  line-height: 1.65;
+}
+.card-arrow {
+  position: absolute;
+  top: 22px;
+  right: 25px;
+  font-size: 20px;
 }
 
-.videos-info a:hover {
-  text-decoration: underline;
+/* Speaker CTA */
+.speaker-callout {
+  padding: 80px 0;
+  background: var(--coral);
+  color: var(--white);
+}
+.callout-inner {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  align-items: center;
+  gap: 60px;
+}
+.callout-kicker {
+  font: 500 11px/1 var(--font-code);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.callout-inner h2 {
+  margin: 9px 0 0;
+  font: 600 clamp(42px, 5vw, 66px)/1 var(--font-display);
+  letter-spacing: -0.055em;
+}
+.callout-inner p {
+  max-width: 430px;
+  margin: 0;
+  line-height: 1.65;
+  color: #fff1ee;
+}
+.button-light {
+  background: var(--white);
+  color: var(--ink);
+  white-space: nowrap;
+}
+.button-light:hover {
+  box-shadow: 0 10px 25px rgba(98, 27, 18, 0.18);
 }
 
+/* Videos */
+.videos-container {
+  width: min(1180px, calc(100% - 48px));
+  margin: 0 auto;
+  padding: 84px 0 110px;
+}
+.videos-header {
+  max-width: 750px;
+  margin-bottom: 45px;
+}
+.videos-header::before {
+  content: 'THE ARCHIVE';
+  display: block;
+  margin-bottom: 18px;
+  color: #2b7c86;
+  font: 500 11px/1 var(--font-code);
+  letter-spacing: 0.12em;
+}
+.videos-header h1 {
+  margin: 0 0 14px;
+  font: 600 clamp(49px, 7vw, 84px)/1 var(--font-display);
+  letter-spacing: -0.06em;
+}
+.videos-header p {
+  margin: 0;
+  color: #60767b;
+  font-size: 18px;
+}
+.videos-info {
+  margin: 0 0 60px;
+  padding: 22px 25px;
+  border-left: 4px solid var(--cyan);
+  background: #e8f1ef;
+  color: #415d64;
+}
+.videos-info a {
+  color: #137b88;
+  font-weight: 700;
+}
 .meetup-group {
-  margin-bottom: 50px;
+  margin-bottom: 70px;
 }
-
 .meetup-group h2 {
-  font-size: 1.8em;
-  color: #21A69A;
-  margin-bottom: 25px;
-  padding-bottom: 10px;
-  border-bottom: 2px solid #21A69A;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  margin: 0 0 25px;
+  font: 600 29px/1 var(--font-display);
 }
-
+.meetup-group h2::after {
+  content: '';
+  height: 1px;
+  flex: 1;
+  background: #cfdbd8;
+}
 .videos-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 30px;
-  margin-bottom: 30px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 22px;
 }
-
 .video-card {
-  background: white;
-  border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  background: var(--white);
+  border: 1px solid #dce5e2;
+  transition:
+    transform 0.25s ease,
+    box-shadow 0.25s ease;
 }
-
 .video-card:hover {
   transform: translateY(-5px);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 16px 40px rgba(7, 25, 31, 0.1);
 }
-
 .video-embed {
   position: relative;
   width: 100%;
   padding-bottom: 56.25%;
   height: 0;
   overflow: hidden;
-  background: #000;
+  background: var(--ink);
 }
-
 .video-embed iframe {
   position: absolute;
-  top: 0;
-  left: 0;
+  inset: 0;
   width: 100%;
   height: 100%;
+  border: 0;
 }
-
 .video-card h3 {
-  font-size: 1.1em;
-  margin: 15px;
-  margin-bottom: 8px;
-  color: #333;
+  margin: 19px 20px 8px;
+  font: 600 17px/1.35 var(--font-display);
+  letter-spacing: -0.02em;
 }
-
 .video-speaker {
-  margin: 0 15px 15px 15px;
-  color: #666;
-  font-size: 0.95em;
+  margin: 0 20px 20px;
+  color: #6f8185;
+  font: 400 11px/1 var(--font-code);
 }
 
-@media only screen and (max-width: 768px) {
+/* Footer */
+.site-footer {
+  padding: 72px 0 25px;
+  background: var(--ink);
+  color: var(--white);
+}
+.footer-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  padding-bottom: 65px;
+}
+.footer-brand {
+  margin-bottom: 24px;
+}
+.footer-grid > div > p {
+  color: #8ea4a9;
+  line-height: 1.65;
+}
+.footer-links {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 30px;
+}
+.footer-links div {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.footer-links span {
+  margin-bottom: 7px;
+  color: #617a80;
+  font: 500 10px/1 var(--font-code);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.footer-links a {
+  width: fit-content;
+  color: #cbd8da;
+  text-decoration: none;
+  font-size: 14px;
+}
+.footer-links a:hover {
+  color: var(--cyan);
+}
+.footer-bottom {
+  padding-top: 23px;
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid var(--line);
+  color: #668086;
+  font-size: 11px;
+}
+
+@media (max-width: 900px) {
+  .hero-layout {
+    grid-template-columns: 1fr;
+    padding-top: 80px;
+  }
+  .hero-copy {
+    text-align: center;
+  }
+  .eyebrow,
+  .hero-actions,
+  .hero-note {
+    justify-content: center;
+  }
+  .hero-lead {
+    margin-inline: auto;
+  }
+  .hero-visual {
+    min-height: 480px;
+  }
+  .stats-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .stat-message {
+    grid-column: 1 / -1;
+    min-height: 62px;
+    border-top: 1px solid rgba(7, 25, 31, 0.16);
+  }
+  .community-grid {
+    grid-template-columns: 1fr;
+  }
+  .section-copy {
+    max-width: 620px;
+  }
+  .callout-inner {
+    grid-template-columns: 1fr 1fr;
+  }
+  .callout-inner .button {
+    grid-column: 1 / -1;
+    width: fit-content;
+  }
+  .videos-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  .shell,
+  .nav-shell,
+  .videos-container {
+    width: min(100% - 30px, 1180px);
+  }
+  .nav-shell {
+    min-height: 70px;
+  }
+  .site-nav {
+    gap: 18px;
+  }
+  .site-nav > a:not(.nav-cta) {
+    display: none;
+  }
+  .nav-cta {
+    font-size: 12px;
+  }
+  .brand-mark {
+    width: 38px;
+    height: 38px;
+  }
+  .hero-layout {
+    gap: 25px;
+    padding: 62px 0 70px;
+  }
+  .hero h1 {
+    font-size: clamp(48px, 15vw, 70px);
+  }
+  .hero-lead {
+    font-size: 16px;
+  }
+  .hero-actions {
+    flex-direction: column;
+  }
+  .hero-actions .button {
+    width: 100%;
+  }
+  .hero-note {
+    align-items: flex-start;
+    text-align: left;
+  }
+  .hero-visual {
+    min-height: 390px;
+  }
+  .gopher-card {
+    width: 280px;
+    min-height: 350px;
+  }
+  .orbit-one {
+    width: 340px;
+    height: 210px;
+  }
+  .orbit-two {
+    width: 300px;
+    height: 380px;
+  }
+  .chip-one {
+    left: 0;
+  }
+  .chip-two {
+    right: 0;
+  }
+  .stats-grid {
+    width: 100%;
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .stat {
+    padding: 20px 8px;
+    text-align: center;
+  }
+  .stat:first-child {
+    border-left: 0;
+  }
+  .stat strong {
+    font-size: 21px;
+  }
+  .stat > span {
+    font-size: 8px;
+  }
+  .stat-message {
+    text-align: left;
+  }
+  .community-section {
+    padding: 80px 0;
+  }
+  .community-cards {
+    grid-template-columns: 1fr;
+  }
+  .feature-card {
+    min-height: 330px;
+  }
+  .speaker-callout {
+    padding: 65px 0;
+  }
+  .callout-inner {
+    grid-template-columns: 1fr;
+    gap: 25px;
+  }
+  .callout-inner .button {
+    grid-column: auto;
+    width: 100%;
+  }
+  .videos-container {
+    padding-top: 60px;
+  }
   .videos-grid {
     grid-template-columns: 1fr;
   }
-
-  .videos-header h1 {
-    font-size: 1.8em;
+  .footer-grid {
+    grid-template-columns: 1fr;
+    gap: 45px;
   }
-
-  .meetup-group h2 {
-    font-size: 1.4em;
+  .footer-bottom {
+    gap: 15px;
+    flex-direction: column;
+  }
+  .footer-bottom span:last-child {
+    display: none;
   }
 }
 
-.bttn.primary:hover {
-  background: #21a69a;
-  box-shadow: inset 3px 4px 10px rgb(35 33 33 / 40%);
-  /* -webkit-box-shadow: inset 3px 4px 10px rgb(35 33 33 / 40%); */
-}
-
-.bttn.secondary{
-  background: transparent;
-  border: #093C4F 2px solid;
-  color: #0D1D24;
-}
-
-.bttn.secondary:hover {
-  background: #05171f;
-  color: white;
-}
-
-.resource-list {
-  font-family: Helvetica, Arial, sans-serif;
-  font-size: larger;
-  text-align: center;
-  width: 100%;
-}
-
-.resource-list ul {
-  text-align: left;
-  margin: 0 auto;
-  list-style: none;
-  display: flex;
-  justify-content: center;
-  padding: 2%;
-}
-
-.resource-list li {
-  padding: 2%;
-  font-weight: bold;
-}
-
-.resource-list a {
-  color: black;
-  line-height: 30px;
-}
-
-footer {
-  margin: 0 auto;
-  width: 100%;
-  text-align: center;
-}
-
-footer img {
-  width: 20px;
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition: none !important;
+  }
 }


### PR DESCRIPTION
## Summary

- redesign the homepage with a modern Go-inspired visual system and stronger meetup calls to action
- add responsive navigation, community highlights, speaker CTA, and a structured footer
- refresh the video archive with responsive cards and lazy-loaded embeds
- preserve the 10-year anniversary destination in the new footer
- improve semantics and accessibility with landmarks, a functional skip link, active navigation states, and reduced-motion support
- update the canonical production URL and current Hugo locale configuration
- add Playwright coverage for desktop Chrome, Android Pixel 7, and iPhone 13/WebKit

## Playwright coverage

- homepage content and every primary community destination
- internal navigation to the complete 37-video archive
- lazy-loaded YouTube embeds
- desktop and mobile viewport overflow/responsive behavior
- mobile navigation behavior
- keyboard skip-link behavior

## Validation

- `make test` — **12 passed** across desktop Chromium, Pixel 7, and iPhone 13/WebKit
- `hugo --destination /tmp/gomeetup-pr-build --cleanDestinationDir --minify`
- LSP diagnostics: no findings
- pi-lens diagnostics: no findings

The new `Playwright tests` GitHub Actions workflow runs this suite on pull requests and pushes to `main`.
