### PR TITLE
Highlight the upcoming meetup

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,3 +2,11 @@ baseURL = 'https://www.gomeetupprague.cz/'
 locale = 'en-US'
 title = 'Go Meetup Prague'
 theme = 'netlify-basic'
+
+# Shown in the homepage meetup banner. Leave blank to hide a value.
+[params.nextMeetup]
+url = 'https://www.meetup.com/prague-golang-meetup/events/315974056/'
+endsAt = '2026-09-23T21:00:00+02:00'
+date = 'Sep 23'
+time = '6:00 PM'
+place = 'Sky Czechia Afi Karlin'

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test'
 
 const externalDestinations = {
   meetup: 'https://www.meetup.com/prague-golang-meetup/',
+  meetupEvent: 'https://www.meetup.com/prague-golang-meetup/events/315974056/',
   slack: 'https://invite.slack.golangbridge.org/',
   mastodon: 'https://fosstodon.org/@gomeetupprague',
   youtube: 'https://www.youtube.com/@gomeetupprague',
@@ -22,9 +23,17 @@ test('homepage exposes every primary community action', async ({ page }) => {
   await expect(page.getByRole('heading', { level: 1 })).toContainText(
     'Build better software.',
   )
+  await expect(page.locator('.meetup-alert')).toHaveAttribute(
+    'href',
+    externalDestinations.meetupEvent,
+  )
+  await expect(page.locator('.meetup-alert-details')).toBeVisible()
+  await expect(page.locator('.meetup-alert-details')).toContainText(
+    'The next Prague Go meetup is coming on Sep 23 at 6:00 PM at Sky Czechia Afi Karlin.',
+  )
   await expect(page.getByRole('link', { name: /join the next meetup/i })).toHaveAttribute(
     'href',
-    externalDestinations.meetup,
+    externalDestinations.meetupEvent,
   )
   await expect(page.getByRole('link', { name: /meet us in/i })).toHaveAttribute(
     'href',
@@ -45,6 +54,13 @@ test('homepage exposes every primary community action', async ({ page }) => {
     'href',
     externalDestinations.anniversary,
   )
+})
+
+test('past meetup banner is hidden', async ({ page }) => {
+  await page.clock.setFixedTime(new Date('2026-09-23T19:00:01Z'))
+  await page.goto('/')
+
+  await expect(page.locator('.meetup-alert')).toBeHidden()
 })
 
 test('navigation opens the complete video archive', async ({ page }) => {

--- a/themes/netlify-basic/layouts/index.html
+++ b/themes/netlify-basic/layouts/index.html
@@ -1,4 +1,22 @@
 {{ define "main" }}
+{{ $nextMeetupURL := .Site.Params.nextMeetup.url | default "https://www.meetup.com/prague-golang-meetup/" }}
+<a
+  id="next-meetup"
+  class="meetup-alert"
+  href="{{ $nextMeetupURL }}"
+  data-ends-at="{{ .Site.Params.nextMeetup.endsAt }}"
+>
+  <span class="shell meetup-alert-inner">
+    <span class="meetup-alert-status"><i aria-hidden="true"></i> Next meetup</span>
+    <strong class="meetup-alert-details">The next Prague Go meetup is coming{{ with .Site.Params.nextMeetup.date }} on {{ . }}{{ end }}{{ with .Site.Params.nextMeetup.time }} at {{ . }}{{ end }}{{ with .Site.Params.nextMeetup.place }} at {{ . }}{{ end }}.</strong>
+    <span class="meetup-alert-action">View details &amp; RSVP <span aria-hidden="true">↗</span></span>
+  </span>
+</a>
+<script>
+  const meetupAlert = document.getElementById('next-meetup');
+  meetupAlert.hidden = Date.now() >= Date.parse(meetupAlert.dataset.endsAt);
+</script>
+
 <section class="hero">
   <div class="hero-glow hero-glow-one" aria-hidden="true"></div>
   <div class="hero-glow hero-glow-two" aria-hidden="true"></div>
@@ -14,7 +32,7 @@
       </p>
       <div class="hero-actions">
         <a
-          href="https://www.meetup.com/prague-golang-meetup/"
+          href="{{ $nextMeetupURL }}"
           class="button button-primary"
           >Join the next meetup <span aria-hidden="true">↗</span></a
         >

--- a/themes/netlify-basic/static/css/demo-styling.css
+++ b/themes/netlify-basic/static/css/demo-styling.css
@@ -124,6 +124,52 @@ img {
   color: var(--ink);
 }
 
+/* Next meetup */
+.meetup-alert {
+  position: relative;
+  z-index: 4;
+  display: block;
+  background: var(--coral);
+  color: var(--white);
+  text-decoration: none;
+}
+.meetup-alert[hidden] {
+  display: none;
+}
+.meetup-alert-inner {
+  min-height: 58px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+.meetup-alert-status {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font: 500 10px/1 var(--font-code);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.meetup-alert-status i {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--cyan);
+  box-shadow: 0 0 0 4px rgba(125, 231, 240, 0.2);
+}
+.meetup-alert strong {
+  font: 600 14px/1.3 var(--font-display);
+}
+.meetup-alert-action {
+  margin-left: auto;
+  font-size: 12px;
+  font-weight: 700;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.55);
+}
+.meetup-alert:hover .meetup-alert-action {
+  border-color: var(--white);
+}
+
 /* Hero */
 .hero {
   position: relative;
@@ -802,6 +848,19 @@ img {
   .brand-mark {
     width: 38px;
     height: 38px;
+  }
+  .meetup-alert-inner {
+    min-height: 76px;
+    flex-wrap: wrap;
+    gap: 7px 16px;
+    padding-block: 13px;
+  }
+  .meetup-alert strong {
+    order: 3;
+    width: 100%;
+  }
+  .meetup-alert-action {
+    margin-left: auto;
   }
   .hero-layout {
     gap: 25px;


### PR DESCRIPTION
## Summary

- add a prominent, responsive upcoming-meetup banner to the homepage
- configure the event URL, date, time, venue, and end timestamp in `config.toml`
- point the RSVP calls to the specific Meetup event
- hide the banner in the browser after the configured event end time
- cover the visible and expired states with Playwright

## Why

Visitors should immediately see the next Prague Go meetup and have a direct path to RSVP. Client-side expiry prevents a finished event from continuing to be promoted without requiring a post-event deploy.

## User impact

The homepage now promotes the September 23 meetup at Sky Czechia and automatically removes the banner after 21:00 CEST.

## Validation

- `npm test` — 15 Playwright tests passed across desktop Chrome, Pixel 7, and iPhone 13
- Hugo production build completed successfully
- `git diff --check` passed
