### PR TITLE
content: add premiere video

### DIFF
--- a/data/videos.json
+++ b/data/videos.json
@@ -4,6 +4,12 @@
       "year": 2026,
       "videos": [
         {
+          "title": "Vilibald Wanca - Nail the Basics - S01E03",
+          "id": "GXjqST2gTe4",
+          "published": "2026-08-09",
+          "url": "https://www.youtube.com/embed/GXjqST2gTe4"
+        },
+        {
           "title": "Marek Svitok (Sky) - Elegance and Safety in Goroutine Management",
           "id": "RwLlsF8rV_A",
           "published": "2026-08-09",

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -71,11 +71,11 @@ test('navigation opens the complete video archive', async ({ page }) => {
   await expect(page.getByRole('heading', { level: 1, name: 'Videos' })).toBeVisible()
 
   const cards = page.locator('.video-card')
-  await expect(cards).toHaveCount(41)
+  await expect(cards).toHaveCount(42)
   await expect(cards.first().getByRole('heading', { level: 3 })).not.toBeEmpty()
 
   const embeds = page.locator('.video-embed iframe')
-  await expect(embeds).toHaveCount(41)
+  await expect(embeds).toHaveCount(42)
   expect(await embeds.evaluateAll((frames) => frames.every((frame) => frame.loading === 'lazy'))).toBe(
     true,
   )


### PR DESCRIPTION
## What changed

- Added `Vilibald Wanca - Nail the Basics - S01E03` to the 2026 video archive
- Updated the browser test’s expected archive and embed counts from 41 to 42

## Why

The video was still in its YouTube premiere when the previous archive update was prepared, so it was not returned in that fetch.

## User impact

Visitors can find and watch the fifth August 2026 recording from the website’s Videos page.

## Validation

- `hugo`
- `git diff --check`
- JSON uniqueness and syntax check with `jq`
- `npm test` — 15 passed
